### PR TITLE
macOS arm64 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,6 +131,9 @@ jobs:
   build_macos:
     name: 'Build a package MacOS'
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: ['x86_64', 'arm64']    
     steps:
       - uses: actions/checkout@v3
       - name: Show GitHub context
@@ -151,6 +154,7 @@ jobs:
         run: './ci/build-osx.sh'
         env:
           SENTRY_AUTH_TOKEN: ${{secrets.SENTRY_AUTH_TOKEN}}
+          ARCHITECTURE: ${{matrix.arch}}
       - name: Put version into package.json
         if: startsWith(github.ref, 'refs/tags/')
         run: node ./ci/bump-version.js "${{ steps.get_version.outputs.VERSION }}" "${{env.PACKAGE_PATH}}"
@@ -160,7 +164,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{env.BUILD_DIRECTORY}}
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-build-${{ github.sha }}
 
   upload_release_package_macos:
     needs: build_macos
@@ -179,14 +183,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ${{env.BUILD_DIRECTORY}}
-          key: ${{ runner.os }}-build-${{ github.sha }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-build-${{ github.sha }}
       - name: Check cache
         if: steps.cache-check.outputs.cache-hit != 'true'
         run: exit 1
       - name: Tar artifact for deployment
         run: tar -cvzf ${{env.TARGET_ARTIFACT}}.tar.gz -C "${{env.INSTALL_DISTRIBUTE_PATH}}" ${{env.PACKAGE_DIRECTORY}}
         env:
-          TARGET_ARTIFACT: ${{env.PACKAGE_NAME}}-${{ steps.get_version.outputs.VERSION }}-${{env.OS_TAG}}
+          TARGET_ARTIFACT: ${{env.PACKAGE_NAME}}-${{ steps.get_version.outputs.VERSION }}-${{env.OS_TAG}}-${{ matrix.arch }}
           INSTALL_DISTRIBUTE_PATH: "${{env.BUILD_DIRECTORY}}/${{env.DISTRIBUTE_DIRECTORY}}"
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -197,4 +201,4 @@ jobs:
       - name: Deploy
         run: aws s3 cp ${{env.TARGET_ARTIFACT}}.tar.gz s3://${{env.RELEASE_BUCKET}} --acl public-read
         env:
-          TARGET_ARTIFACT: ${{env.PACKAGE_NAME}}-${{ steps.get_version.outputs.VERSION }}-${{env.OS_TAG}}
+          TARGET_ARTIFACT: ${{env.PACKAGE_NAME}}-${{ steps.get_version.outputs.VERSION }}-${{env.OS_TAG}}-${{ matrix.arch }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,7 +133,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        arch: ['x86_64', 'arm64']    
+        arch: ['x86_64', 'arm64']
     steps:
       - uses: actions/checkout@v3
       - name: Show GitHub context
@@ -170,6 +170,9 @@ jobs:
     needs: build_macos
     name: 'Upload release package macos'
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: ['x86_64', 'arm64']
     if: startsWith(github.ref, 'refs/tags/')
     env:
       OS_TAG: "osx"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,26 @@
 cmake_minimum_required(VERSION 3.0)
 project(node_libuiohook)
 
+if(APPLE)
+	if (NOT CMAKE_OSX_ARCHITECTURES)
+		set(CMAKE_OSX_ARCHITECTURES "${CMAKE_HOST_SYSTEM_PROCESSOR}")
+	endif()
+	if (NOT CMAKE_OSX_DEPLOYMENT_TARGET)
+		if ("${CMAKE_OSX_ARCHITECTURES}" STREQUAL "arm64")
+			set(CMAKE_OSX_DEPOLYMENT_TARGET "11.0")
+		else()
+			set(CMAKE_OSX_DEPLOYMENT_TARGET "10.15")
+		endif()
+	endif()
+endif()
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake")
 
 #############################
 # CMake Settings
 #############################
 
-SET(NODEJS_URL "https://electronjs.org/headers" CACHE STRING "Node.JS URL")
+SET(NODEJS_URL "https://artifacts.electronjs.org/headers/dist" CACHE STRING "Node.JS URL")
 SET(NODEJS_NAME "iojs" CACHE STRING "Node.JS Name")
 SET(NODEJS_VERSION "v17.4.11" CACHE STRING "Node.JS Version")
 

--- a/ci/build-osx.sh
+++ b/ci/build-osx.sh
@@ -2,9 +2,14 @@ set -e
 
 brew install wget
 
+if [ ! -n "${ARCHITECTURE}" ]
+then
+    ARCHITECTURE=$(uname -m)
+fi
+
 # Download libuiohook dependency
-export DEPS="libuiohook-osx-1.2-sl.0"
-wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3-us-west-2.amazonaws.com/libuiohook-osx-1.2-sl.0.tar.gz
+export DEPS="libuiohook-osx-1.2-${ARCHITECTURE}-sl.0"
+wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3-us-west-2.amazonaws.com/libuiohook-osx-1.2-${ARCHITECTURE}-sl.0.tar.gz
 
 mkdir build
 cd build
@@ -12,12 +17,20 @@ cd build
 mkdir deps
 tar -xf ../${DEPS}.tar.gz -C ./deps
 
+if [ -n "${ELECTRON_VERSION}" ]
+then
+    NODEJS_VERSION_PARAM="-DNODEJS_VERSION=${ELECTRON_VERSION}"
+else
+    NODEJS_VERSION_PARAM=""
+fi
+
 # Configure
 cmake .. \
--DCMAKE_OSX_DEPLOYMENT_TARGET=10.11 \
+-DCMAKE_OSX_DEPLOYMENT_TARGET=10.15 \
 -DUIOHOOKDIR=${PWD}/deps/${DEPS} \
 -DCMAKE_BUILD_TYPE=RelWithDebInfo \
--DNODEJS_VERSION=${ELECTRON_VERSION} \
+${NODEJS_VERSION_PARAM} \
+-DCMAKE_OSX_ARCHITECTURES=${ARCHITECTURE} \
 -DCMAKE_INSTALL_PREFIX=${DISTRIBUTE_DIRECTORY}/node-libuiohook
 
 cd ..

--- a/ci/build-osx.sh
+++ b/ci/build-osx.sh
@@ -8,8 +8,8 @@ then
 fi
 
 # Download libuiohook dependency
-export DEPS="libuiohook-osx-1.2-${ARCHITECTURE}-sl.0"
-wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3-us-west-2.amazonaws.com/libuiohook-osx-1.2-${ARCHITECTURE}-sl.0.tar.gz
+export DEPS="libuiohook-osx-1.2.2-b230208-${ARCHITECTURE}"
+wget --quiet --retry-connrefused --waitretry=1 https://obs-studio-deployment.s3-us-west-2.amazonaws.com/libuiohook-osx-1.2.2-b230208-${ARCHITECTURE}.tar.gz
 
 mkdir build
 cd build

--- a/ci/macos-deps/create-libuiohook-package.zsh
+++ b/ci/macos-deps/create-libuiohook-package.zsh
@@ -1,0 +1,145 @@
+#!/bin/zsh
+
+# 1. Put the script to an empty folder
+# 2. ./create-libuiohook-package.zsh --architecture=arm64
+# 3. ./create-libuiohook-package.zsh --architecture=x86_64
+
+download_libuihook() {
+    # Check if the webrtc folder exists
+    if [ -d "${GIT_FOLDER}" ]
+    then
+        echo "### The '${GIT_FOLDER}' folder exists. It will be reused. Remove it if you want to clone the git repositoty again."
+        return
+    fi
+
+    echo "### Downloading sources ..."
+
+    # Clone
+    git clone --recurse-submodules https://github.com/kwhat/libuiohook ${GIT_FOLDER}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not clone libuihook!"
+        exit 1
+    fi
+
+    # Checkout correct tag
+    cd "${GIT_FOLDER_NAME}"
+    git checkout -b branch-for-tag-${GIT_TAG} ${GIT_TAG}
+    if [ $? -ne 0 ]
+    then
+        echo "### Could not checkout the appropriate branch."
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+
+    # Check if the source folder name is correct and the folder exists
+    if [ ! -d "${GIT_FOLDER}" ]
+    then
+        echo "### The source folder '${GIT_FOLDER}' could not be found. Probably the 'git clone' command failed. Please check manually!"
+        exit 1
+    fi
+}
+
+build_libuihook() {
+
+    echo "### Building ..."
+
+    # Prepare build parameters
+    case "${ARCHITECTURE}" in
+        arm64)
+            MIN_MACOS_VERSION=11.0
+            ;;
+        x86_64)
+            MIN_MACOS_VERSION=10.15
+            ;;
+        *)
+            echo "### Unknown architecture! Only 'arm64' or 'x86_64' is supported."
+            exit 1
+            ;;
+    esac
+
+    cd "${GIT_FOLDER}"
+
+    # Check if the build folder exists
+    if [ -d "${BUILD_FOLDER}" ]
+    then
+        echo "### The '${BUILD_FOLDER}' folder exists. Configuring will be skiped. Remove the folder if you want to configure from scratch."
+        cd "${BUILD_FOLDER}"
+    else
+        echo "### Configuring ..."
+
+        mkdir -p "${BUILD_FOLDER}"
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not create the build folder: ${BUILD_FOLDER}!"
+            exit 1
+        fi
+        cd "${BUILD_FOLDER}"
+        cmake -S .. -DBUILD_SHARED_LIBS=ON -DCMAKE_OSX_ARCHITECTURES="${ARCHITECTURE}" -DCMAKE_OSX_DEPLOYMENT_TARGET=${MIN_MACOS_VERSION} -DCMAKE_INSTALL_PREFIX=${PACKAGE_FOLDER}
+        if [ $? -ne 0 ]
+        then
+            echo "### Could not configure!"
+            cd "${INITIAL_WORKING_FOLDER}"
+            exit 1
+        fi
+    fi    
+
+    echo "### Building ..."
+
+    cmake --build . --target install
+    if [ $? -ne 0 ]
+    then
+        echo "### Build failed!"
+        cd "${INITIAL_WORKING_FOLDER}"
+        exit 1
+    fi
+}
+
+package_libuihook() {
+    # Copy the script
+    echo "### Copying this script ..."
+    cp "${SCRIPT_PATH}" "${PACKAGE_FOLDER}" 
+
+    cd ${INITIAL_WORKING_FOLDER}
+
+    # Compress
+    echo "### Compressing ..."
+    tar cvzf ${PACKAGE_FOLDER_NAME}.tar.gz ${PACKAGE_FOLDER_NAME}    
+}
+
+# SCRIPT START
+
+ARCHITECTURE=$(uname -m)
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --architecture=*)
+            ARCHITECTURE="${1#*=}"
+            ;;
+        *)
+            echo "### Error: Invalid command line parameter. Please use --architecture=arm64 or --architecture=x86_64"
+            exit 1
+    esac
+    shift
+done
+
+INITIAL_WORKING_FOLDER=${PWD}
+SCRIPT_PATH=$(realpath $0)
+GIT_FOLDER_NAME=libuiohook
+GIT_FOLDER=${INITIAL_WORKING_FOLDER}/${GIT_FOLDER_NAME}
+GIT_TAG=1.2.2
+BUILD_FOLDER_NAME=build-${ARCHITECTURE}
+BUILD_FOLDER=${GIT_FOLDER}/${BUILD_FOLDER_NAME}
+PACKAGE_FOLDER_NAME=libuiohook-osx-${GIT_TAG}-b$(date +'%y%m%d')-${ARCHITECTURE}
+PACKAGE_FOLDER=${INITIAL_WORKING_FOLDER}/${PACKAGE_FOLDER_NAME}
+
+# Check if git is available
+if ! command -v git &> /dev/null
+then
+    echo "'git' could not be found. Please install 'git' and start the script again."
+    exit 1
+fi
+
+download_libuihook
+build_libuihook
+package_libuihook


### PR DESCRIPTION
- Modified build.yml, CMakeLists.txt and build-osx.sh to build macOS packages for both x86_64/arm64 architectures
- Electron version v17.4.11
- Minimal macOS version 10.15
- Recompiled libuiohook for both architectures
- Added a script for libuiohook